### PR TITLE
日付変数が正しく動作しない

### DIFF
--- a/lib/date-ext.js
+++ b/lib/date-ext.js
@@ -22,25 +22,25 @@ DateExt =  function (date) {
     this.day = function() { return this._date.getDate(); };
     this.hour = function() { return this._date.getHours(); };
     this.min = function() { return this._date.getMinutes(); };
-    this.Month = function() { return formatNum(2, this.month); };
-    this.Day = function() { return formatNum(2, this.day); };
-    this.Hour = function() { return formatNum(2, this.hour); };
-    this.Min = function() { return formatNum(2, this.min); };
+    this.Month = function() { return formatNum(2, this.month()); };
+    this.Day = function() { return formatNum(2, this.day()); };
+    this.Hour = function() { return formatNum(2, this.hour()); };
+    this.Min = function() { return formatNum(2, this.min()); };
 
     this.to_s_date = function() {
-        return this.year  + "/" + this.Month + "/" + this.Day;
+        return this.year()  + "/" + this.Month() + "/" + this.Day();
     };
 
     this.to_s_Date = function() {
-        return this.year  + "-" + this.Month + "-" + this.Day;
+        return this.year()  + "-" + this.Month() + "-" + this.Day();
     };
 
     this.to_s_dateTime = function() {
-        return this.year  + "/" + this.Month + "/" + this.Day + " " + this.Hour + " =" + this.Min;
+        return this.year()  + "/" + this.Month() + "/" + this.Day() + " " + this.Hour() + " =" + this.Min();
     };
 
     this.to_s_DateTime = function() {
-        return this.year  + "-" + this.Month + "-" + this.Day + " " + this.Hour + ":" + this.Min;
+        return this.year()  + "-" + this.Month() + "-" + this.Day() + " " + this.Hour() + ":" + this.Min();
     };
 };
 


### PR DESCRIPTION
当方のFirefox 45.0.1において、日付変数が正しく動作しなかったので修正してみました。
たとえば「%date%」と設定した場合、正しくは「2016/04/04」がコピーされるはずですが、
function () { return this._date.getFullYear(); }/function () { return formatNum(2, this.month()); }/function () { return formatNum(2, this.day()); }
となります。
lib/date-ext.js内の関数名の後に()を追記することで正しく動作するようになりましたので、
報告を兼ねてプルリクエストいたします。
