### PR TITLE
リンクフォーマットのグローバルマッチのバグを修正

### DIFF
--- a/lib/firelink_lib.js
+++ b/lib/firelink_lib.js
@@ -19,16 +19,16 @@ exports.chainText = function(text) {
 
 exports.parseDate = function(linkform, dateExt) {
   let r = linkform;
-  r = r.replace("%date%", dateExt.to_s_date(), "g");
-  r = r.replace("%Date%", dateExt.to_s_Date(), "g");
-  r = r.replace("%datetime%", dateExt.to_s_dateTime(), "g");
-  r = r.replace("%DateTime%", dateExt.to_s_DateTime(), "g");
-  r = r.replace("%year%", dateExt.year(), "g");
-  r = r.replace("%month%", dateExt.Month(), "g");
-  r = r.replace("%day%", dateExt.Day(), "g");
-  r = r.replace("%hour%", dateExt.Hour(), "g");
-  r = r.replace("%min%", dateExt.Min(), "g");
-  r = r.replace("%min%", dateExt.Min(), "g");
+  r = r.replace(/%date%/g, dateExt.to_s_date());
+  r = r.replace(/%Date%/g, dateExt.to_s_Date());
+  r = r.replace(/%datetime%/g, dateExt.to_s_dateTime());
+  r = r.replace(/%DateTime%/g, dateExt.to_s_DateTime());
+  r = r.replace(/%year%/g, dateExt.year());
+  r = r.replace(/%month%/g, dateExt.Month());
+  r = r.replace(/%day%/g, dateExt.Day());
+  r = r.replace(/%hour%/g, dateExt.Hour());
+  r = r.replace(/%min%/g, dateExt.Min());
+  r = r.replace(/%min/g, dateExt.Min());
   return r;
 }
 
@@ -36,11 +36,11 @@ exports.isgd = function(linkform, url) {
   let r = linkform;
 
   if (r.indexOf("%isgd%") != -1)
-    r = r.replace("%isgd%", isGd.createShortUrl(url, storage.shortening), "g");
+    r = r.replace(/%isgd%/g, isGd.createShortUrl(url, storage.shortening));
 
   // since isgd is not the only option.
   if (r.indexOf("%short%") != -1)
-    r = r.replace("%short%", isGd.createShortUrl(url, storage.shortening), "g");
+    r = r.replace(/%short%/g, isGd.createShortUrl(url, storage.shortening));
 
   return r;
 }
@@ -63,15 +63,15 @@ exports.wikiname = function(url) {
 
 exports.createText = function(linkform, linkdata) {
   var r = linkform;
-  r = r.replace("%text%", linkdata.text, "g");
-  r = r.replace("%title%", linkdata.title, "g");
-  r = r.replace("%url%", linkdata.url, "g");
-  r = r.replace("%wikiname%", exports.wikiname(linkdata.url), "g");
-  r = r.replace("\n", " ", "g");
+  r = r.replace(/%text%/g, linkdata.text);
+  r = r.replace(/%title%/g, linkdata.title);
+  r = r.replace(/%url%/g, linkdata.url);
+  r = r.replace(/%wikiname%/g, exports.wikiname(linkdata.url));
+  r = r.replace(/\n/g, " ");
   r = exports.parseDate(r, new dateExt.DateExt(new Date()));
   r = exports.isgd(r, linkdata.url);
-  r = r.replace("\\t", "\t", "g");
-  r = r.replace("\\n", "\n", "g");
+  r = r.replace(/\\t/g, "\t");
+  r = r.replace(/\\n/g, "\n");
   return r;
 }
 


### PR DESCRIPTION
リンクフォーマットで同じプレースホルダを複数登録した場合、最初のプレースホルダしか置換できないバグを修正しました。
